### PR TITLE
CanBus to Victron CCGX

### DIFF
--- a/TeslaBMS.ino
+++ b/TeslaBMS.ino
@@ -568,14 +568,16 @@ void loop_vecan() // communication with Victron system over CAN
   Logger::debug("VECan %i %i", msg.id, msg.buf[0]);
   CANVE.write(msg);
 
-  // bms firmware version
+  // bms firmware version and battery current
   msg.flags.extended = 0;
   msg.id = 0x35F;
-  msg.len = 4;
+  msg.len = 6;
   msg.buf[0] = 0x01;
   msg.buf[1] = 0x00;
   msg.buf[2] = lowByte(bsmFWV[0]);
   msg.buf[3] = lowByte(bsmFWV[1]);
+  msg.buf[4] = lowByte(uint16_t(status.QBattCurr));
+  msg.buf[5] = highByte(uint16_t(status.QBattCurr));
   Logger::debug("VECan %i %i", msg.id, msg.buf[0]);
   CANVE.write(msg);
 }

--- a/TeslaBMS.ino
+++ b/TeslaBMS.ino
@@ -580,6 +580,19 @@ void loop_vecan() // communication with Victron system over CAN
   msg.buf[5] = highByte(uint16_t(status.QBattCurr));
   Logger::debug("VECan %i %i", msg.id, msg.buf[0]);
   CANVE.write(msg);
+
+  msg.id  = 0x372; // modules info
+  msg.len = 8;
+  msg.buf[0] = lowByte(uint16_t(bms.numFoundModules));                                      // System/NrOfModulesOnline
+  msg.buf[1] = highByte(uint16_t(bms.numFoundModules));
+  msg.buf[2] = lowByte(uint16_t(0));                                                        // System/NrOfModulesBlockingCharge
+  msg.buf[3] = highByte(uint16_t(0));
+  msg.buf[4] = lowByte(uint16_t(0));                                                        // System/NrOfModulesBlockingDischarge
+  msg.buf[5] = highByte(uint16_t(0));
+  msg.buf[6] = lowByte(uint16_t(settings.ConfigBattParallelStrings - bms.numFoundModules)); // System/NrOfModulesOffline
+  msg.buf[7] = highByte(uint16_t(settings.ConfigBattParallelStrings - bms.numFoundModules));
+  Logger::debug("VECan %i %i", msg.id, msg.buf[0]);
+  CANVE.write(msg);
 }
 
 void loop_readcan(const CAN_message_t &msg)

--- a/TeslaBMS.ino
+++ b/TeslaBMS.ino
@@ -488,13 +488,11 @@ void loop_vecan() // communication with Victron system over CAN
 
   msg.flags.extended = 0;
   msg.id = 0x355;
-  msg.len = 6;
+  msg.len = 4;
   msg.buf[0] = (byte)(status.SocBattCurr * 100.0f);
   msg.buf[1] = 0;
   msg.buf[2] = (byte)(status.SohBattCurr * 100.0f);
   msg.buf[3] = 0;
-  msg.buf[4] = 0; //should be 0.01% SOC but does not work for me
-  msg.buf[5] = 0;
   Logger::debug("VECan %i %i", msg.id, msg.buf[0]);
   CANVE.write(msg);
 

--- a/config.h
+++ b/config.h
@@ -22,7 +22,8 @@
 #define INBMBFAULT 11
 
 // Victron Bus
-#define CANVE Can0        // TX 3, RX 4
+#define CAN_DEV CAN0
+#define CAN_PIN DEF         // TX 3, RX 4
 
 // Status LED
 #define LED  13       


### PR DESCRIPTION
i had some issues where the BMS would sometimes not show up as not connected on the ccgx
and the updated library [FlexCAN_T4](https://github.com/tonton81/FlexCAN_T4) solved that issue.
also its a bit more updated.

in addition I've moved the values for the bms name and manufacture to the top and construct the message according to the array.

a few new can messages are added too that fill out some of the pages on the ccgx.
i have not found the correct messages yet for the number of battery modules and modules blocking charge/discharge
